### PR TITLE
Added base template, to fix 404s and other pages from `common`

### DIFF
--- a/mtp_emails/templates/base.html
+++ b/mtp_emails/templates/base.html
@@ -1,0 +1,3 @@
+{% extends 'mtp_common/mtp_base.html' %}
+{% load i18n %}
+{% load mtp_common %}


### PR DESCRIPTION
`400`s, `404`s and `500`s pages all come from `mtp_common`.
However a base template is still require to avoid an exception.