### PR TITLE
Set header app name as generic 'Prisoner Money'

### DIFF
--- a/mtp_emails/templates/govuk-frontend/components/header.html
+++ b/mtp_emails/templates/govuk-frontend/components/header.html
@@ -1,0 +1,5 @@
+{% extends 'govuk-frontend/components/header.html' %}
+{% load i18n %}
+
+
+{% block proposition %}{% trans 'Prisoner Money' %}{% endblock %}


### PR DESCRIPTION
Without this the header would show "Send money to someone in prison"
which is equally wrong and confusing.