### PR TITLE
MTP-1921: Add Azure Application Insights request tracing and logging

### DIFF
--- a/emails.ini
+++ b/emails.ini
@@ -1,7 +1,7 @@
 [uwsgi]
 procname = uwsgi_%n
 die-on-term = 1
-lazy-apps = 0
+lazy-apps = 1
 vacuum = 1
 
 master = true

--- a/mtp_emails/settings/base.py
+++ b/mtp_emails/settings/base.py
@@ -211,6 +211,13 @@ LOGGING = {
         },
     },
 }
+if APPLICATIONINSIGHTS_CONNECTION_STRING:
+    # Sends messages from `mtp` logger to Azure Application Insights
+    LOGGING['handlers']['azure'] = {
+        'level': 'INFO',
+        'class': 'mtp_common.application_insights.AppInsightsLogHandler',
+    }
+    LOGGING['loggers']['mtp']['handlers'].append('azure')
 
 # sentry exception handling
 if os.environ.get('SENTRY_DSN'):

--- a/mtp_emails/settings/base.py
+++ b/mtp_emails/settings/base.py
@@ -82,6 +82,20 @@ MIDDLEWARE = (
     'mtp_common.analytics.ReferrerPolicyMiddleware',
 )
 
+APPLICATIONINSIGHTS_CONNECTION_STRING = os.environ.get('APPLICATIONINSIGHTS_CONNECTION_STRING')
+if APPLICATIONINSIGHTS_CONNECTION_STRING:
+    from mtp_common.application_insights import AppInsightsTraceExporter
+    from opencensus.trace.samplers import ProbabilitySampler
+
+    # Sends traces to Azure Application Insights
+    MIDDLEWARE += ('opencensus.ext.django.middleware.OpencensusMiddleware',)
+    OPENCENSUS = {
+        'TRACE': {
+            'SAMPLER': ProbabilitySampler(rate=0.1 if ENVIRONMENT == 'prod' else 1),
+            'EXPORTER': AppInsightsTraceExporter(),
+        }
+    }
+
 HEALTHCHECKS = []
 AUTODISCOVER_HEALTHCHECKS = True
 

--- a/mtp_emails/settings/base.py
+++ b/mtp_emails/settings/base.py
@@ -218,6 +218,7 @@ if APPLICATIONINSIGHTS_CONNECTION_STRING:
         'class': 'mtp_common.application_insights.AppInsightsLogHandler',
     }
     LOGGING['loggers']['mtp']['handlers'].append('azure')
+    LOGGING['root']['handlers'].append('azure')
 
 # sentry exception handling
 if os.environ.get('SENTRY_DSN'):

--- a/mtp_emails/tasks.py
+++ b/mtp_emails/tasks.py
@@ -1,3 +1,5 @@
+import django
 from mtp_common.spooling import autodiscover_tasks
 
+django.setup()
 autodiscover_tasks()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=13.9.1
+money-to-prisoners-common~=13.10.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=13.9.1
+money-to-prisoners-common[testing]~=13.10.0
 
 -r base.txt


### PR DESCRIPTION
uWSGI now runs in lazy mode such that each process loads its own complete application rather than forking the master. This now requires the spooler to setup django.

Lazy apps are needed if telemetry is to be sent to Azure Application Insights: the `opencensus` library starts a background thread on launch to transport telemetry to Azure, but if uWSGI loads the application and _then_ forks, this thread is no longer accessible from the new process.

In `prod` environment:
• `mtp` logs of level INFO and higher
• other logs of level WARNING and higher
• 10% of requests traces
…will be sent.

Depends on [common#539](https://github.com/ministryofjustice/money-to-prisoners-common/pull/539).