### PR TITLE
Django 4.2

### DIFF
--- a/mtp_emails/settings/docker.py
+++ b/mtp_emails/settings/docker.py
@@ -33,6 +33,5 @@ if ENVIRONMENT != 'local':
     # strict-transport set at nginx level
     # SECURE_HSTS_SECONDS = 31536000
     # SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-    SECURE_BROWSER_XSS_FILTER = True
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True

--- a/mtp_emails/urls.py
+++ b/mtp_emails/urls.py
@@ -1,8 +1,8 @@
 from django.conf import settings
-from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
+from django.urls import include, re_path
 from django.views.decorators.cache import cache_control
 from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
@@ -11,28 +11,28 @@ from mtp_common.metrics.views import metrics_view
 
 
 urlpatterns = i18n_patterns(
-    url(r'^', include('downloads.urls',)),
+    re_path(r'^', include('downloads.urls',)),
 
-    url(r'^js-i18n.js$', cache_control(public=True, max_age=86400)(JavaScriptCatalog.as_view()), name='js-i18n'),
+    re_path(r'^js-i18n.js$', cache_control(public=True, max_age=86400)(JavaScriptCatalog.as_view()), name='js-i18n'),
 
-    url(r'^404.html$', lambda request: TemplateResponse(request, 'mtp_common/errors/404.html', status=404)),
-    url(r'^500.html$', lambda request: TemplateResponse(request, 'mtp_common/errors/500.html', status=500)),
+    re_path(r'^404.html$', lambda request: TemplateResponse(request, 'mtp_common/errors/404.html', status=404)),
+    re_path(r'^500.html$', lambda request: TemplateResponse(request, 'mtp_common/errors/500.html', status=500)),
 )
 
 urlpatterns += [
-    url(r'^', include('callbacks.urls',)),
+    re_path(r'^', include('callbacks.urls',)),
 
-    url(r'^ping.json$', PingJsonView.as_view(
+    re_path(r'^ping.json$', PingJsonView.as_view(
         build_date_key='APP_BUILD_DATE',
         commit_id_key='APP_GIT_COMMIT',
         version_number_key='APP_BUILD_TAG',
     ), name='ping_json'),
-    url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
-    url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
+    re_path(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
+    re_path(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 
-    url(r'^favicon.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon.ico', permanent=True)),
-    url(r'^robots.txt$', lambda request: HttpResponse('User-agent: *\nDisallow: /', content_type='text/plain')),
-    url(r'^\.well-known/security\.txt$', RedirectView.as_view(
+    re_path(r'^favicon.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon.ico', permanent=True)),
+    re_path(r'^robots.txt$', lambda request: HttpResponse('User-agent: *\nDisallow: /', content_type='text/plain')),
+    re_path(r'^\.well-known/security\.txt$', RedirectView.as_view(
         url='https://security-guidance.service.justice.gov.uk/.well-known/security.txt',
         permanent=True,
     )),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=17.1.0
+money-to-prisoners-common~=18.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=17.1.0
+money-to-prisoners-common[testing]~=18.0.0
 
 -r base.txt


### PR DESCRIPTION
Changes needed to upgrade to Django 4.x (currently 3.2 is in use).

NOTE: So far this is not using Django 4.x but these are changes required to upgrade (e.g. because something deprecated was removed)