### PR TITLE
IR-1740 Remove test-env deploy from emails CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,6 @@ orbs:
   aws-cli: circleci/aws-cli@5
   aws-ecr: circleci/aws-ecr@9
 
-parameters:
-  kubectl-version:
-    type: string
-    description: version of kubectl binary to use
-    default: v1.32.9
-
 jobs:
   build-test-push:
     executor:
@@ -39,13 +33,6 @@ jobs:
       - aws-cli/setup:
           region: ${AWS_DEFAULT_REGION}
           role_arn: ${ECR_ROLE_TO_ASSUME}
-      - run:
-          name: Install kubectl
-          command: |
-            curl -LO https://dl.k8s.io/release/<< pipeline.parameters.kubectl-version >>/bin/linux/amd64/kubectl
-            echo "$(curl -L -s https://dl.k8s.io/release/<< pipeline.parameters.kubectl-version >>/bin/linux/amd64/kubectl.sha256) kubectl" | sha256sum --check
-            sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-            kubectl version --client --output yaml
       - run:
           name: Log docker into ECR
           command: |
@@ -106,24 +93,6 @@ jobs:
           command: |
             . /tmp/mtp-env.sh
             docker logout ${ECR_REGISTRY}
-      - run:
-          name: Deploy to test
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "main" ]]; then
-              . /tmp/mtp-env.sh
-              echo "Deploying to test"
-
-              echo -n ${K8S_CLUSTER_CERT} | base64 -d > /tmp/mtp-k8s-ca.crt
-              kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=/tmp/mtp-k8s-ca.crt --server=${K8S_CLUSTER_SERVER}
-              kubectl config set-credentials circleci --token=${K8S_TOKEN}
-              kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
-              kubectl config use-context ${K8S_CLUSTER_NAME}
-              IMAGE=${registry}:${tag}
-              kubectl patch configmap app-versions --patch "{\"data\": {\"${app}\": \"${version}\"}}"
-              kubectl patch deployment ${app} --type strategic --patch "{\"metadata\": {\"annotations\": {\"kubernetes.io/change-cause\": \"${version}\"}}, \"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"app\", \"image\": \"${IMAGE}\"}], \"initContainers\": [{\"name\": \"copy-static\", \"image\": \"${IMAGE}\"}]}}}}"
-            else
-              echo "Not deploying to test"
-            fi
       - run:
           name: Clean up ECR
           command: |


### PR DESCRIPTION
## What

Removes the `Deploy to test` and `Install kubectl` steps (and the now-unused `kubectl-version` parameter) from emails's CircleCI config. CircleCI keeps `build → test → push → clean`.

## Why

GitHub Actions now owns the test-env deploy for emails — **verified**: on the latest `main` run the GitHub Actions `Deploy to test` step authenticated to the cluster and patched the `emails` deployment successfully. Removing CircleCI's deploy means only one system patches the cluster.

Follows the cashbook cutover (cashbook#632). Intentionally diverges this repo's `.circleci/config.yml` from the shared generator template (the apps still on CircleCI keep the shared deploy step); the file is removed entirely when emails's CircleCI is retired in the final cleanup.