### PR TITLE
IR-1782 Build the dev image from GHCR instead of ECR

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -2,8 +2,7 @@
 # see `docker compose` documentation in money-to-prisoners-common
 # vim: ft=dockerfile
 
-ARG ECR_REGISTRY
-FROM ${ECR_REGISTRY}/prisoner-money/money-to-prisoners:emails
+FROM ghcr.io/ministryofjustice/money-to-prisoners-emails:latest
 
 # Need to escalate to root to move virtual environment outside codebase
 USER root


### PR DESCRIPTION
Phase 5 of IR-1782 — **the change the ticket was actually raised for.**

## Why

Bringing up the local stack currently requires AWS credentials. Every
`Dockerfile-dev` is based on the private ECR image:

```dockerfile
ARG ECR_REGISTRY
FROM ${ECR_REGISTRY}/prisoner-money/money-to-prisoners:<app>
```

so a developer needed access to the private deploy repository, the ECR registry
address, a `.env` file, and `aws ecr get-login-password` before
`docker-compose up` would do anything at all.

## What changes

One line. The dev image is now based on the public GHCR package, which docker
pulls anonymously:

```dockerfile
FROM ghcr.io/ministryofjustice/money-to-prisoners-<app>:latest
```

Nothing else in the file changes.

## Paired change

The matching removal of the `ECR_REGISTRY` build arg is in
ministryofjustice/money-to-prisoners-common — **both need to merge** for
`docker-compose` to work end to end. This one is harmless on its own: the build
arg simply stops being consumed.

## Verified

Logged out of ghcr.io and with `AWS_*`, `GITHUB_TOKEN` and `ECR_REGISTRY` all
unset, the new base reference resolves and pulls:

```
$ docker pull ghcr.io/ministryofjustice/money-to-prisoners-<app>:latest
ghcr.io/ministryofjustice/money-to-prisoners-<app>:latest
```
