### PR TITLE
IR-1782 Fix the build badge and link to the service documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Application to handle emails links to download files and GOV.UK Notify callbacks.
 
+How this app fits into the wider service — architecture, data flows, deployment and
+support — is documented in [money-to-prisoners-deploy](https://github.com/ministryofjustice/money-to-prisoners-deploy/blob/main/docs/README.md).
+
 ## Why this application exists
 
 ### Email links
@@ -70,7 +73,7 @@ and you should be able to connect to the local server.
 
 ## Developing
 
-[![CircleCI](https://circleci.com/gh/ministryofjustice/money-to-prisoners-emails.svg?style=svg)](https://circleci.com/gh/ministryofjustice/money-to-prisoners-emails)
+[![Build, test and push](https://github.com/ministryofjustice/money-to-prisoners-emails/actions/workflows/build-test-push.yml/badge.svg)](https://github.com/ministryofjustice/money-to-prisoners-emails/actions/workflows/build-test-push.yml)
 
 With the `./run.py` command, you can run a browser-sync server, and get the assets
 to automatically recompile when changes are made, run `./run.py serve` instead of


### PR DESCRIPTION
Part of a documentation refresh ahead of two developers joining — see [deploy#548](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/548) for the service-wide docs this links to.

- **Replaces the CircleCI build badge with the GitHub Actions one.** The badge pointed at a CI system that no longer runs, so it was showing a broken image on the front page of the repo.
- **Links to the new service documentation** — architecture, data flows, deployment, secrets and support.

No other changes.
